### PR TITLE
[10.0][crm_claim_rma] Improve performance when creating a picking from rma

### DIFF
--- a/crm_claim_rma/wizards/claim_make_picking.py
+++ b/crm_claim_rma/wizards/claim_make_picking.py
@@ -76,9 +76,9 @@ class ClaimMakePicking(models.TransientModel):
         lines = self.env['claim.line'].\
             search(domain)
         if lines:
-            domain = domain + ['|', (move_field, '=', False),
-                               (move_field + '.state', '=', 'cancel')]
-            lines = lines.search(domain)
+            lines = lines.filtered(
+                lambda l: getattr(getattr(l, move_field), 'state') == 'cancel'
+                or not getattr(l, move_field))
             if not lines:
                 raise exceptions.UserError(
                     _('A picking has already been created for this claim.')


### PR DESCRIPTION
Hello,
I use this module for customers with big volumes in version 8 and 9, and this part can take a really long time when there are a lot of canceled stock.move in the database.

This small refactore is way faster and make more sense.

What do you think? @max3903 
I make the PR here since it is not yet merged in OCA