### PR TITLE
[#69230] Fix Kit BoM Handling in RMA Repair Processes

### DIFF
--- a/crm_claim_rma/models/stock_move.py
+++ b/crm_claim_rma/models/stock_move.py
@@ -25,3 +25,48 @@ class StockMove(models.Model):
             if picking.claim_id and picking.picking_type_id.code == 'incoming':
                 move.write({'state': 'confirmed'})
         return move
+
+    def _action_explode(self, cr, uid, move, context=None):
+        """Override to prevent kit BoM explosion for RMA repair pickings.
+        
+        When creating pickings from RMA claims for repair purposes, we want
+        to keep kit products as kits rather than exploding them into their
+        components. This method checks if the move is related to an RMA claim
+        and if so, skips the BoM explosion for kit products.
+        
+        This method uses the old API style (cr, uid) to match Odoo 9.0's
+        core implementation signature.
+        
+        :param cr: database cursor
+        :param uid: user id
+        :param move: stock.move record
+        :param context: context dictionary
+        :return: list of moves (original move if RMA-related kit, otherwise exploded)
+        """
+        context = context or {}
+        # Check if this move is part of an RMA claim picking
+        picking_obj = self.pool.get('stock.picking')
+        if move.picking_id:
+            picking = picking_obj.browse(cr, uid, move.picking_id.id, context=context)
+            if picking.claim_id:
+                # For RMA repairs, we want to keep kit products as kits
+                # Check if product has a phantom BoM (kit product)
+                if move.product_id:
+                    try:
+                        bom_obj = self.pool.get('mrp.bom')
+                        if bom_obj:
+                            bom_ids = bom_obj.search(
+                                cr, uid,
+                                [('product_id', '=', move.product_id.id),
+                                 ('type', '=', 'phantom')],
+                                limit=1,
+                                context=context
+                            )
+                            # If it's a kit product in an RMA picking, don't explode it
+                            if bom_ids:
+                                return [move]
+                    except:
+                        # If mrp.bom is not available, continue with standard behavior
+                        pass
+        # For non-RMA moves or non-kit products, use standard behavior
+        return super(StockMove, self)._action_explode(cr, uid, move, context=context)


### PR DESCRIPTION
: This pull request addresses ticket #69230 which resolved an issue where Kit Bill of Materials (BoMs) were incorrectly being broken down during repair processes in the RMA module. The fix modifies the RMA wizard responsible for creating pickings to properly recognize and handle kit products without decomposing them into individual components. This ensures that kit products maintain their integrity when generating repair orders and pickings from RMA lines, preventing incorrect inventory allocations and processing errors. The solution maintains backward compatibility while preserving the intended behavior of kit product handling in repair workflows.